### PR TITLE
Adding two sided bracket

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,13 +151,46 @@ const Component = () => {
 };
 ```
 
+### Two-sided Single Elimination
+
+How to render Single Elimination as a two-sided bracket? You must set twoSided to true, and structure your custom seed render component like below, if you have a custom seed render component.
+
+```jsx
+import { Bracket, RoundProps, Seed, SeedItem, SeedTeam, RenderSeedProps } from 'react-brackets';
+import React from 'react';
+
+const CustomSeed = ({seed, breakpoint, roundIndex, seedIndex, isMiddleOfTwoSided}: RenderSeedProps) => {
+  // breakpoint passed to Bracket component
+  // to check if mobile view is triggered or not
+
+  // mobileBreakpoint is required to be passed down to a seed
+  const Wrapper = isMiddleOfTwoSided ? SingleLineSeed : Seed
+  return (
+    <Wrapper mobileBreakpoint={breakpoint} style={{ fontSize: 12 }}>
+      <SeedItem>
+        <div>
+          <SeedTeam style={{ color: 'red' }}>{seed.teams[0]?.name || 'NO TEAM '}</SeedTeam>
+          <SeedTeam>{seed.teams[1]?.name || 'NO TEAM '}</SeedTeam>
+        </div>
+      </SeedItem>
+    </Wrapper>
+  );
+};
+
+const Component = () => {
+  //....
+  return <Bracket rounds={rounds} renderSeedComponent={CustomSeed} twoSided={true} />;
+};
+```
+
 ## Bracket Props
 
 | Prop                | Type                 | Description                                                                                                                                                              |
-| ------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|---------------------| -------------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | rounds              | RoundProps[]         | Array of rounds, each round has {title,array of seeds}, if you're not using a custom seed render, each seed needs an array of teams, each team should have a name        |
 | mobileBreakpoint    | number               | This bracket supports responsive design, on window reaching this size, it will trigger mobile swipable view, if you want to disable it, you can pass 0, (default is 992) |
 | rtl                 | boolean              | Direction of the bracket as RTL (default is LTR)                                                                                                                         |
+| twoSided            | boolean              | Sets Single elimination to be two sided if true. Default is False                                                                                                        |
 | roundClassName      | string               | Round wrapper className                                                                                                                                                  |
 | bracketClassName    | string               | The bracket className                                                                                                                                                    |
 | renderSeedComponent | functional component | Custom render for every seed                                                                                                                                             |

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import DoubleElimination from './components/double-elimination';
 import LoadingBracket from './components/loading';
 import SingleElimination from './components/single-elimination';
+import TwoSidedSingleElimination from "./components/two-sided-single-elimination";
 
 const App = () => {
   return (
@@ -15,6 +16,9 @@ const App = () => {
       <h3>Double Elimination</h3>
       <hr />
       <DoubleElimination />
+      <h3>Two Sided Single Elimination</h3>
+      <hr />
+      <TwoSidedSingleElimination />
     </div>
   );
 };

--- a/example/src/components/two-sided-single-elimination/index.tsx
+++ b/example/src/components/two-sided-single-elimination/index.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { Bracket, Seed, SingleLineSeed, SeedItem, SeedTeam, SeedTime, IRoundProps, IRenderSeedProps } from 'react-brackets';
+
+const rounds: IRoundProps[] = [
+  {
+    title: 'Quarter Finals',
+    seeds: [
+      {
+        id: 1,
+        date: new Date().toDateString(),
+        teams: [
+          { id: 1, name: 'Team 1', score: 2 },
+          { id: 3, name: 'Team 2', score: 6 },
+        ],
+      },{
+        id: 1,
+        date: new Date().toDateString(),
+        teams: [
+          { id: 1, name: 'Team 3', score: 2 },
+          { id: 3, name: 'Team 4', score: 6 },
+        ],
+      },{
+        id: 1,
+        date: new Date().toDateString(),
+        teams: [
+          { id: 1, name: 'Team 5', score: 2 },
+          { id: 3, name: 'Team 6', score: 6 },
+        ],
+      },
+      {
+        id: 1,
+        date: new Date().toDateString(),
+        teams: [
+          { id: 1, name: 'The Leons', score: 2 },
+          { id: 3, name: 'Kitties', score: 6 },
+        ],
+      },
+    ],
+  },
+  {
+    title: 'Semi Finals',
+    seeds: [
+      {
+      id: 1,
+      date: new Date().toDateString(),
+      teams: [
+        { id: 1, name: 'Team 1', score: 2 },
+        { id: 3, name: 'Team 3', score: 6 },
+      ],
+    },{
+        id: 1,
+        date: new Date().toDateString(),
+        teams: [
+          { id: 1, name: 'The Leons', score: 2 },
+          { id: 3, name: 'Team 5', score: 6 },
+        ],
+      },]
+  },
+  {
+    title: 'Final',
+    seeds: [...new Array(1)].fill({
+      id: 1,
+      date: new Date().toDateString(),
+      teams: [
+        { id: 1, name: 'The Leons', score: 2 },
+        { id: 3, name: 'Team 1', score: 6 },
+      ],
+    }),
+  },
+];
+
+const RenderSeed = ({ breakpoint, seed, isMiddleOfTwoSided }: IRenderSeedProps) => {
+  const Wrapper = isMiddleOfTwoSided ? SingleLineSeed : Seed
+  return (
+    <Wrapper mobileBreakpoint={breakpoint} seed={seed}>
+      <SeedItem style={{ width: '100%' }}>
+        <div>
+          <SeedTeam>{seed.teams?.[0].name || '-----------'}</SeedTeam>
+          <div style={{ height: 1, backgroundColor: '#707070' }}></div>
+          <SeedTeam>{seed.teams?.[1]?.name || '-----------'}</SeedTeam>
+        </div>
+      </SeedItem>
+      <SeedTime mobileBreakpoint={breakpoint} style={{ fontSize: 9 }}>
+        {seed.date}
+      </SeedTime>
+    </Wrapper>
+  );
+};
+
+const TwoSidedSingleElimination = () => {
+  return (
+    <Bracket
+      mobileBreakpoint={767}
+      rounds={rounds}
+      renderSeedComponent={RenderSeed}
+      swipeableProps={{ enableMouseEvents: true, animateHeight: true }}
+      twoSided={true}
+    />
+  );
+};
+
+export default TwoSidedSingleElimination;

--- a/src/brackets/index.tsx
+++ b/src/brackets/index.tsx
@@ -21,17 +21,6 @@ const SingleElimination = ({
   // Checking responsive size
   const isResponsive = useMedia(mobileBreakpoint);
 
-  const data = rounds.map((round, roundIdx) => (
-    <Round key={round.title} className={roundClassName} mobileBreakpoint={mobileBreakpoint}>
-      {round.title && roundTitleComponent(round.title, roundIdx)}
-      <SeedsList>
-        {round.seeds.map((seed, idx) => {
-          return getFragment(seed, roundIdx, idx, rounds, false)
-        })}
-      </SeedsList>
-    </Round>
-  ));
-
   const getFragment = (seed: ISeedProps, roundIdx: number, idx: number, rounds: IRoundProps[], isMiddleOfTwoSided: any) =>
     <Fragment key={seed.id}>
       {renderSeedComponent({
@@ -43,6 +32,17 @@ const SingleElimination = ({
         isMiddleOfTwoSided
       })}
     </Fragment>;
+
+  const data = rounds.map((round, roundIdx) => (
+    <Round key={round.title} className={roundClassName} mobileBreakpoint={mobileBreakpoint}>
+      {round.title && roundTitleComponent(round.title, roundIdx)}
+      <SeedsList>
+        {round.seeds.map((seed, idx) => {
+          return getFragment(seed, roundIdx, idx, rounds, false)
+        })}
+      </SeedsList>
+    </Round>
+  ));
 
   if (isResponsive) {
     // Since SwipeableViewsProps have an issue that it uses ref inside of it, We need to remove ref from the object

--- a/src/brackets/index.tsx
+++ b/src/brackets/index.tsx
@@ -4,6 +4,8 @@ import SwipeableViews from 'react-swipeable-views';
 import useMedia from '../hooks/useMedia';
 import { renderSeed, renderTitle } from '../utils/renders';
 import { ISingleEliminationProps } from '../types/SingleElimination';
+import { IRoundProps } from '../types/Rounds';
+import {ISeedProps} from "../types/Seed";
 
 const SingleElimination = ({
   rounds,
@@ -12,6 +14,7 @@ const SingleElimination = ({
   bracketClassName,
   swipeableProps = {},
   mobileBreakpoint = 992,
+  twoSided = false,
   renderSeedComponent = renderSeed,
   roundTitleComponent = renderTitle,
 }: ISingleEliminationProps) => {
@@ -23,21 +26,23 @@ const SingleElimination = ({
       {round.title && roundTitleComponent(round.title, roundIdx)}
       <SeedsList>
         {round.seeds.map((seed, idx) => {
-          return (
-            <Fragment key={seed.id}>
-              {renderSeedComponent({
-                seed,
-                breakpoint: mobileBreakpoint,
-                roundIndex: roundIdx,
-                seedIndex: idx,
-                rounds,
-              })}
-            </Fragment>
-          );
+          return getFragment(seed, roundIdx, idx, rounds, false)
         })}
       </SeedsList>
     </Round>
   ));
+
+  const getFragment = (seed: ISeedProps, roundIdx: number, idx: number, rounds: IRoundProps[], isMiddleOfTwoSided: any) =>
+    <Fragment key={seed.id}>
+      {renderSeedComponent({
+        seed,
+        breakpoint: mobileBreakpoint,
+        roundIndex: roundIdx,
+        seedIndex: idx,
+        rounds,
+        isMiddleOfTwoSided
+      })}
+    </Fragment>;
 
   if (isResponsive) {
     // Since SwipeableViewsProps have an issue that it uses ref inside of it, We need to remove ref from the object
@@ -50,6 +55,37 @@ const SingleElimination = ({
       </Bracket>
     );
   }
+
+  const getRenderedRounds = (
+    roundsStartIndex: number,
+    roundsEndIndex: number,
+    renderFirstHalfOfRoundsSeeds: boolean,
+    rounds: IRoundProps[],
+    dir: string) =>
+    rounds.slice(roundsStartIndex, roundsEndIndex).map((round, roundIdx) => (
+      <Round key={round.title} className={roundClassName} mobileBreakpoint={mobileBreakpoint}>
+        {round.title && roundTitleComponent(round.title, roundIdx)}
+        <SeedsList dir={dir}>
+          {renderFirstHalfOfRoundsSeeds
+            ? round.seeds.slice(0, round.seeds.length / 2).map((seed, idx) => getFragment(seed, roundIdx, idx, rounds, false))
+            : round.seeds.slice(round.seeds.length / 2, round.seeds.length).map((seed, idx) => (getFragment(seed, roundIdx, idx, rounds, roundIdx < roundsEndIndex - 2 ? true : false))
+              )}
+        </SeedsList>
+      </Round>
+    ));
+
+  if (twoSided) {
+    return (
+      <Bracket className={bracketClassName} mobileBreakpoint={mobileBreakpoint}>
+        {[
+          getRenderedRounds(0, rounds.length - 1, true, rounds, "ltr"),
+          getRenderedRounds(rounds.length - 1, rounds.length, false, rounds, "twoSided"),
+          getRenderedRounds(1, rounds.length, false, [...rounds].reverse(), "rtl"),
+        ]}
+      </Bracket>
+    );
+  }
+
   return (
     <Bracket className={bracketClassName} dir={rtl ? 'rtl' : 'ltr'} mobileBreakpoint={mobileBreakpoint}>
       {data}

--- a/src/brackets/index.tsx
+++ b/src/brackets/index.tsx
@@ -5,7 +5,7 @@ import useMedia from '../hooks/useMedia';
 import { renderSeed, renderTitle } from '../utils/renders';
 import { ISingleEliminationProps } from '../types/SingleElimination';
 import { IRoundProps } from '../types/Rounds';
-import {ISeedProps} from "../types/Seed";
+import { ISeedProps } from '../types/Seed';
 
 const SingleElimination = ({
   rounds,
@@ -21,7 +21,13 @@ const SingleElimination = ({
   // Checking responsive size
   const isResponsive = useMedia(mobileBreakpoint);
 
-  const getFragment = (seed: ISeedProps, roundIdx: number, idx: number, rounds: IRoundProps[], isMiddleOfTwoSided: any) =>
+  const getFragment = (
+    seed: ISeedProps,
+    roundIdx: number,
+    idx: number,
+    rounds: IRoundProps[],
+    isMiddleOfTwoSided: any
+  ) => (
     <Fragment key={seed.id}>
       {renderSeedComponent({
         seed,
@@ -29,16 +35,17 @@ const SingleElimination = ({
         roundIndex: roundIdx,
         seedIndex: idx,
         rounds,
-        isMiddleOfTwoSided
+        isMiddleOfTwoSided,
       })}
-    </Fragment>;
+    </Fragment>
+  );
 
   const data = rounds.map((round, roundIdx) => (
     <Round key={round.title} className={roundClassName} mobileBreakpoint={mobileBreakpoint}>
       {round.title && roundTitleComponent(round.title, roundIdx)}
       <SeedsList>
         {round.seeds.map((seed, idx) => {
-          return getFragment(seed, roundIdx, idx, rounds, false)
+          return getFragment(seed, roundIdx, idx, rounds, false);
         })}
       </SeedsList>
     </Round>
@@ -61,15 +68,19 @@ const SingleElimination = ({
     roundsEndIndex: number,
     renderFirstHalfOfRoundsSeeds: boolean,
     rounds: IRoundProps[],
-    dir: string) =>
+    dir: string
+  ) =>
     rounds.slice(roundsStartIndex, roundsEndIndex).map((round, roundIdx) => (
       <Round key={round.title} className={roundClassName} mobileBreakpoint={mobileBreakpoint}>
         {round.title && roundTitleComponent(round.title, roundIdx)}
         <SeedsList dir={dir}>
           {renderFirstHalfOfRoundsSeeds
-            ? round.seeds.slice(0, round.seeds.length / 2).map((seed, idx) => getFragment(seed, roundIdx, idx, rounds, false))
-            : round.seeds.slice(round.seeds.length / 2, round.seeds.length).map((seed, idx) => (getFragment(seed, roundIdx, idx, rounds, roundIdx < roundsEndIndex - 2 ? true : false))
-              )}
+            ? round.seeds
+                .slice(0, round.seeds.length / 2)
+                .map((seed, idx) => getFragment(seed, roundIdx, idx, rounds, false))
+            : round.seeds
+                .slice(round.seeds.length / 2, round.seeds.length)
+                .map((seed, idx) => getFragment(seed, roundIdx, idx, rounds, roundIdx < roundsEndIndex - 2))}
         </SeedsList>
       </Round>
     ));
@@ -78,9 +89,9 @@ const SingleElimination = ({
     return (
       <Bracket className={bracketClassName} mobileBreakpoint={mobileBreakpoint}>
         {[
-          getRenderedRounds(0, rounds.length - 1, true, rounds, "ltr"),
-          getRenderedRounds(rounds.length - 1, rounds.length, false, rounds, "twoSided"),
-          getRenderedRounds(1, rounds.length, false, [...rounds].reverse(), "rtl"),
+          getRenderedRounds(0, rounds.length - 1, true, rounds, 'ltr'),
+          getRenderedRounds(rounds.length - 1, rounds.length, false, rounds, 'twoSided'),
+          getRenderedRounds(1, rounds.length, false, [...rounds].reverse(), 'rtl'),
         ]}
       </Bracket>
     );

--- a/src/components/seed.ts
+++ b/src/components/seed.ts
@@ -64,6 +64,9 @@ font-size: 14px;
     [dir="rtl"] & {
       left: -1.5em;
     }
+    [dir="twoSided"] & {
+      left: -1.5em;
+    }
     [dir="ltr"] & {
       right: -1.5em;
     }

--- a/src/types/Seed.ts
+++ b/src/types/Seed.ts
@@ -12,6 +12,7 @@ export interface IRenderSeedProps {
   seed: ISeedProps;
   breakpoint: number;
   roundIndex: number;
+  isMiddleOfTwoSided: boolean;
   seedIndex: number;
   rounds?: IRoundProps[];
 }

--- a/src/types/SingleElimination.ts
+++ b/src/types/SingleElimination.ts
@@ -26,4 +26,6 @@ export interface ISingleEliminationProps {
    * @param {number} roundIdx the current round index
    */
   renderSeedComponent?: (props: IRenderSeedProps) => JSX.Element;
+  /** @default false, if true component will be two-sided tournament **/
+  twoSided?: boolean;
 }

--- a/src/utils/renders.tsx
+++ b/src/utils/renders.tsx
@@ -8,7 +8,7 @@ export const renderTitle = (title: string | JSX.Element) => <RoundTitle>{title}<
 
 /* ------------------------- default seed component ------------------------- */
 export const renderSeed = ({ seed, breakpoint, isMiddleOfTwoSided }: IRenderSeedProps) => {
-  const Wrapper = isMiddleOfTwoSided ? SingleLineSeed : Seed
+  const Wrapper = isMiddleOfTwoSided ? SingleLineSeed : Seed;
   return (
     <Wrapper mobileBreakpoint={breakpoint}>
       <SeedItem>

--- a/src/utils/renders.tsx
+++ b/src/utils/renders.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Seed, SeedItem, SeedTeam, SeedTime } from '../components/seed';
+import { Seed, SeedItem, SeedTeam, SeedTime, SingleLineSeed } from '../components/seed';
 import { RoundTitle } from '../components/round';
 import { IRenderSeedProps } from '../types/Seed';
 
@@ -7,9 +7,10 @@ import { IRenderSeedProps } from '../types/Seed';
 export const renderTitle = (title: string | JSX.Element) => <RoundTitle>{title}</RoundTitle>;
 
 /* ------------------------- default seed component ------------------------- */
-export const renderSeed = ({ seed, breakpoint }: IRenderSeedProps) => {
+export const renderSeed = ({ seed, breakpoint, isMiddleOfTwoSided }: IRenderSeedProps) => {
+  const Wrapper = isMiddleOfTwoSided ? SingleLineSeed : Seed
   return (
-    <Seed mobileBreakpoint={breakpoint}>
+    <Wrapper mobileBreakpoint={breakpoint}>
       <SeedItem>
         <div>
           <SeedTeam>{seed.teams?.[0]?.name || '-----------'}</SeedTeam>
@@ -17,6 +18,6 @@ export const renderSeed = ({ seed, breakpoint }: IRenderSeedProps) => {
         </div>
       </SeedItem>
       <SeedTime mobileBreakpoint={breakpoint}>{seed?.date}</SeedTime>
-    </Seed>
+    </Wrapper>
   );
 };


### PR DESCRIPTION
This pr adds support for two sided brackets with Single Elimination.

Single Elimination now has an optional boolean flag, twoSided, which defaults to false.

If twoSided is true, the rounds are rendered up to the last round, but with only the first half of each round's seeds rendered. 
Then the last round's seed is rendered.
Finally, the rounds are again rendered up to the last round, but this time the second half of each round's seeds are rendered. 

![web](https://github.com/mohux/react-brackets/assets/88001922/d2ee3031-cff6-4a77-ac0e-4844271d42bc)

![image](https://github.com/mohux/react-brackets/assets/88001922/24b2a5af-3c9e-4834-83cb-bbac4d9115ef)

code for example above: [example/src/components/two-sided-single-elimination/index.tsx](https://github.com/mohux/react-brackets/compare/master...Oliver-Looney:addingTwoSidedBracket?expand=1#diff-453df1c0022629ff0d879e1263e69280ee9ae24045005dd3c355a54b31aaf07c)